### PR TITLE
Fix compilation on MSVC

### DIFF
--- a/vorbiscomment/vcomment.c
+++ b/vorbiscomment/vcomment.c
@@ -90,6 +90,10 @@ void close_files(param_t *p, int output_written);
 
 static void _vorbis_comment_rm_tag(vorbis_comment *vc, const char *tag, const char *contents);
 
+#ifdef _MSC_VER
+#define strncasecmp _strnicmp
+#endif
+
 char * read_line (FILE *input)
 {
         /* Construct a list of buffers. Each buffer will hold 1024 bytes. If


### PR DESCRIPTION
strncasecmp() does not exist in MSVC so define it as _strnicmp()