### PR TITLE
vcut: fix segmentation fault caused by submit_headers_to_stream()

### DIFF
--- a/vcut/vcut.c
+++ b/vcut/vcut.c
@@ -181,7 +181,7 @@ static int submit_headers_to_stream(vcut_state *s)
 	for(i=0;i<4;i++)
 	{
 		ogg_packet p;
-		if(i < 4)  /* a header packet */
+		if(i < 3)  /* a header packet */
 		{
 			p.bytes = vs->headers[i].length;
 			p.packet = vs->headers[i].packet;


### PR DESCRIPTION
There is a regression in vcut that caused a segmentation fault every time I run this program.
It was introduced by commit f7cb48a75de43af793b0399382faec39fcb9b495 (Flush stream after the third header packet, and delay the writing of … )

In `submit_headers_to_stream()`, `vs->headers` is only 3 structures long (as defined in `vcut.h`) so accessing `vs->headers[3]` is certainly a mistake. Moreover, in this function, i is always smaller then 4 so the comparision `if(i < 4)` makes no sense. The Author probably intended to write `if (i<3)`, which fits with the general modifications of `submit_hedears_to_stream` in commit f7cb48a75de43af793b0399382faec39fcb9b495 .

I am running Ubuntu 16.04 i386, maybe this bug does not cause segmentation faults on 64-bit architectures.