### PR TITLE
include utf8.h for utf8_decode()

### DIFF
--- a/ogginfo/codec_skeleton.c
+++ b/ogginfo/codec_skeleton.c
@@ -25,7 +25,7 @@
 #include <ogg/ogg.h>
 
 #include "i18n.h"
-
+#include "utf8.h"
 #include "private.h"
 
 typedef struct {


### PR DESCRIPTION
`ogginfo/codec_skeleton.c` calls `utf8_decode()` but does not include `thf8.h`,
resulting in the following compilation error on macOS 12.3.1:

```
codec_skeleton.c:118:9: error: implicit declaration of function 'utf8_decode' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    if (utf8_decode(header, &decoded) < 0) {
        ^
```
