### PR TITLE
getopt.h: remove leading double underscore from argc/argv

### DIFF
--- a/include/getopt.h
+++ b/include/getopt.h
@@ -131,20 +131,20 @@ struct option
 /* Many other libraries have conflicting prototypes for getopt, with
    differences in the consts, in stdlib.h.  To avoid compilation
    errors, only prototype getopt for the GNU C library.  */
-extern int getopt (int __argc, char *const *__argv, const char *__shortopts);
+extern int getopt (int argc, char *const *argv, const char *__shortopts);
 # else /* not __GNU_LIBRARY__ */
 extern int getopt ();
 # endif /* __GNU_LIBRARY__ */
 
 # ifndef __need_getopt
-extern int getopt_long (int __argc, char *const *__argv, const char *__shortopts,
+extern int getopt_long (int argc, char *const *argv, const char *__shortopts,
 		        const struct option *__longopts, int *__longind);
-extern int getopt_long_only (int __argc, char *const *__argv,
+extern int getopt_long_only (int argc, char *const *argv,
 			     const char *__shortopts,
 		             const struct option *__longopts, int *__longind);
 
 /* Internal only.  Users should not call this directly.  */
-extern int _getopt_internal (int __argc, char *const *__argv,
+extern int _getopt_internal (int argc, char *const *argv,
 			     const char *__shortopts,
 		             const struct option *__longopts, int *__longind,
 			     int __long_only);


### PR DESCRIPTION
causes an error on Windows due to __argc and __argv being defined to something else

Signed-off-by: Christopher Degawa <ccom@randomderp.com>

Closes https://github.com/xiph/vorbis-tools/issues/38