### PR TITLE
fix build with gcc >= 14

### DIFF
--- a/ogginfo/codec_skeleton.c
+++ b/ogginfo/codec_skeleton.c
@@ -28,6 +28,8 @@
 
 #include "private.h"
 
+#include "utf8.h"
+
 typedef struct {
     bool supported;
     uint16_t version_major;

--- a/share/utf8.c
+++ b/share/utf8.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "charset.h"
 #include "utf8.h"
 
 


### PR DESCRIPTION
Add missing includes to avoid the following build failure with gcc >= 14:

```
codec_skeleton.c: In function 'skeleton_process_fisbone_message_header': codec_skeleton.c:119:9: error: implicit declaration of function 'utf8_decode' [-Wimplicit-function-declaration]
  119 |     if (utf8_decode(header, &decoded) < 0) {
      |         ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/bb5d56d836e7d0f2a62daa9954878ad6e0b190ed